### PR TITLE
Fixing links in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-## How to contribute to the vlingo-net-wire
+## How to contribute to the vlingo-net-cluster
 
 #### **Did you find a bug?**
 
-* Make sure the bug was not already reported here: [Issues](https://github.com/vlingo-net/vlingo-net-wire/issues).
+* Make sure the bug was not already reported here: [Issues](https://github.com/vlingo-net/vlingo-net-cluster/issues).
 
-* If nonexisting, open a new issue for the problem: [Open New Issue](https://github.com/vlingo-net/vlingo-net-wire/issues/new). Always provide a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* If nonexisting, open a new issue for the problem: [Open New Issue](https://github.com/vlingo-net/vlingo-net-cluster/issues/new). Always provide a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 #### **Patches and bug fixes**
 


### PR DESCRIPTION
Some links pointed to `Vlingo.Wire` instead of Cluster