### PR TITLE
Removing Task and async await as underlying wire is full async

### DIFF
--- a/src/Vlingo.Cluster.Tests/Model/Outbound/MockManagedOutboundChannel.cs
+++ b/src/Vlingo.Cluster.Tests/Model/Outbound/MockManagedOutboundChannel.cs
@@ -7,7 +7,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using Vlingo.Actors.TestKit;
 using Vlingo.Wire.Fdx.Outbound;
 using Vlingo.Wire.Message;
@@ -26,13 +25,12 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
 
         public void Close() => Writes.Clear();
 
-        public Task Write(Stream buffer)
+        public void Write(Stream buffer)
         {
             var message = RawMessage.ReadFromWithHeader(buffer);
             var textMessage = message.AsTextMessage();
             Writes.Add(textMessage);
             Until.Happened();
-            return Task.CompletedTask;
         }
         
         public Id Id { get; }

--- a/src/Vlingo.Cluster.Tests/Model/Outbound/OperationalOutboundStreamTest.cs
+++ b/src/Vlingo.Cluster.Tests/Model/Outbound/OperationalOutboundStreamTest.cs
@@ -6,7 +6,6 @@
 // one at https://mozilla.org/MPL/2.0/.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Vlingo.Actors;
 using Vlingo.Actors.TestKit;
 using Vlingo.Cluster.Model.Message;
@@ -29,9 +28,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         private TestWorld _world;
 
         [Fact]
-        public async Task TestDirectory()
+        public void TestDirectory()
         {
-            await _outboundStream.Actor.Directory(new HashSet<Node>(Config.AllNodes));
+            _outboundStream.Actor.Directory(new HashSet<Node>(Config.AllNodes));
 
             foreach (var channel in AllTargetChannels())
             {
@@ -42,9 +41,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestElect()
+        public void TestElect()
         {
-            await _outboundStream.Actor.Elect(Config.AllGreaterNodes(_localNodeId));
+            _outboundStream.Actor.Elect(Config.AllGreaterNodes(_localNodeId));
 
             foreach (var channel in AllTargetChannels())
             {
@@ -55,9 +54,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestJoin()
+        public void TestJoin()
         {
-            await _outboundStream.Actor.Join();
+            _outboundStream.Actor.Join();
 
             foreach (var channel in AllTargetChannels())
             {
@@ -68,9 +67,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestLeader()
+        public void TestLeader()
         {
-            await _outboundStream.Actor.Leader();
+            _outboundStream.Actor.Leader();
 
             foreach (var channel in AllTargetChannels())
             {
@@ -81,11 +80,11 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestLeaderOfId()
+        public void TestLeaderOfId()
         {
             var targetId = Id.Of(3);
             
-            await _outboundStream.Actor.Leader(targetId);
+            _outboundStream.Actor.Leader(targetId);
 
             var channel = _channelProvider.ChannelFor(targetId);
             var message = OperationalMessage.MessageFrom(Mock(channel).Writes[0]);
@@ -94,9 +93,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestLeave()
+        public void TestLeave()
         {
-            await _outboundStream.Actor.Leave();
+            _outboundStream.Actor.Leave();
 
             foreach (var channel in AllTargetChannels())
             {
@@ -107,11 +106,11 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestPing()
+        public void TestPing()
         {
             var targetId = Id.Of(3);
             
-            await _outboundStream.Actor.Ping(targetId);
+            _outboundStream.Actor.Ping(targetId);
 
             var channel = _channelProvider.ChannelFor(targetId);
             var message = OperationalMessage.MessageFrom(Mock(channel).Writes[0]);
@@ -120,11 +119,11 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestPulseToTarget()
+        public void TestPulseToTarget()
         {
             var targetId = Id.Of(3);
             
-            await _outboundStream.Actor.Pulse(targetId);
+            _outboundStream.Actor.Pulse(targetId);
 
             var channel = _channelProvider.ChannelFor(targetId);
             var message = OperationalMessage.MessageFrom(Mock(channel).Writes[0]);
@@ -133,9 +132,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestPulse()
+        public void TestPulse()
         {
-            await _outboundStream.Actor.Pulse();
+            _outboundStream.Actor.Pulse();
 
             foreach (var channel in AllTargetChannels())
             {
@@ -146,12 +145,12 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestSplit()
+        public void TestSplit()
         {
             var targetNodeId = Id.Of(2);
             var currentLeaderId = Id.Of(3);
     
-            await _outboundStream.Actor.Split(targetNodeId, currentLeaderId);
+            _outboundStream.Actor.Split(targetNodeId, currentLeaderId);
     
             var channel = _channelProvider.ChannelFor(targetNodeId);
             var message = OperationalMessage.MessageFrom(Mock(channel).Writes[0]);
@@ -160,11 +159,11 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestVote()
+        public void TestVote()
         {
             var targetNodeId = Id.Of(2);
             
-            await _outboundStream.Actor.Vote(targetNodeId);
+            _outboundStream.Actor.Vote(targetNodeId);
 
             var channel = _channelProvider.ChannelFor(targetNodeId);
             var message = OperationalMessage.MessageFrom(Mock(channel).Writes[0]);

--- a/src/Vlingo.Cluster.Tests/Model/Outbound/OutboundTest.cs
+++ b/src/Vlingo.Cluster.Tests/Model/Outbound/OutboundTest.cs
@@ -7,7 +7,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using Vlingo.Wire.Message;
 using Vlingo.Wire.Node;
 using Xunit;
@@ -28,7 +27,7 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         private readonly Outbound _outbound;
 
         [Fact]
-        public async Task TestBroadcast()
+        public void TestBroadcast()
         {
             var buffer = new MemoryStream(Properties.OperationalBufferSize());
     
@@ -36,9 +35,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
             var rawMessage2 = BuildRawMessageBuffer(buffer, _message2);
             var rawMessage3 = BuildRawMessageBuffer(buffer, _message3);
     
-            await _outbound.Broadcast(rawMessage1);
-            await _outbound.Broadcast(rawMessage2);
-            await _outbound.Broadcast(rawMessage3);
+            _outbound.Broadcast(rawMessage1);
+            _outbound.Broadcast(rawMessage2);
+            _outbound.Broadcast(rawMessage3);
 
             foreach (var channel in _channelProvider.AllOtherNodeChannels.Values)
             {
@@ -51,7 +50,7 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
 
         [Fact]
-        public async Task TestBroadcastPooledByteBuffer()
+        public void TestBroadcastPooledByteBuffer()
         {
             var buffer1 = _pool.Access();
             var buffer2 = _pool.Access();
@@ -64,9 +63,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
             var rawMessage3 = BuildRawMessageBuffer((MemoryStream)buffer3.AsStream(), _message3);
             BytesFrom(rawMessage3, (MemoryStream)buffer3.AsStream());
             
-            await _outbound.Broadcast(buffer1);
-            await _outbound.Broadcast(buffer2);
-            await _outbound.Broadcast(buffer3);
+            _outbound.Broadcast(buffer1);
+            _outbound.Broadcast(buffer2);
+            _outbound.Broadcast(buffer3);
             
             foreach (var channel in _channelProvider.AllOtherNodeChannels.Values)
             {
@@ -79,7 +78,7 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestBroadcastToSelectNodes()
+        public void TestBroadcastToSelectNodes()
         {
             var buffer = new MemoryStream(Properties.OperationalBufferSize());
     
@@ -90,9 +89,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
             var selectNodes = new List<Wire.Node.Node>();
             selectNodes.Add(Config.NodeMatching(Id.Of(3)));
             
-            await _outbound.Broadcast(selectNodes, rawMessage1);
-            await _outbound.Broadcast(selectNodes, rawMessage2);
-            await _outbound.Broadcast(selectNodes, rawMessage3);
+            _outbound.Broadcast(selectNodes, rawMessage1);
+            _outbound.Broadcast(selectNodes, rawMessage2);
+            _outbound.Broadcast(selectNodes, rawMessage3);
             
             var mock = (MockManagedOutboundChannel) _channelProvider.ChannelFor(Id.Of(3));
             
@@ -102,7 +101,7 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestSendTo()
+        public void TestSendTo()
         {
             var buffer = new MemoryStream(Properties.OperationalBufferSize());
     
@@ -112,9 +111,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
 
             var id3 = Id.Of(3);
             
-            await _outbound.SendTo(rawMessage1, id3);
-            await _outbound.SendTo(rawMessage2, id3);
-            await _outbound.SendTo(rawMessage3, id3);
+            _outbound.SendTo(rawMessage1, id3);
+            _outbound.SendTo(rawMessage2, id3);
+            _outbound.SendTo(rawMessage3, id3);
             
             var mock = (MockManagedOutboundChannel) _channelProvider.ChannelFor(Id.Of(3));
             
@@ -124,7 +123,7 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
         }
         
         [Fact]
-        public async Task TestSendToPooledByteBuffer()
+        public void TestSendToPooledByteBuffer()
         {
             var buffer1 = _pool.Access();
             var buffer2 = _pool.Access();
@@ -139,9 +138,9 @@ namespace Vlingo.Cluster.Tests.Model.Outbound
             
             var id3 = Id.Of(3);
             
-            await _outbound.SendTo(buffer1, id3);
-            await _outbound.SendTo(buffer2, id3);
-            await _outbound.SendTo(buffer3, id3);
+            _outbound.SendTo(buffer1, id3);
+            _outbound.SendTo(buffer2, id3);
+            _outbound.SendTo(buffer3, id3);
             
             var mock = (MockManagedOutboundChannel) _channelProvider.ChannelFor(Id.Of(3));
             

--- a/src/Vlingo.Cluster/Model/Outbound/IOperationalOutboundStream.cs
+++ b/src/Vlingo.Cluster/Model/Outbound/IOperationalOutboundStream.cs
@@ -6,7 +6,6 @@
 // one at https://mozilla.org/MPL/2.0/.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Vlingo.Actors;
 using Vlingo.Cluster.Model.Message;
 using Vlingo.Wire.Fdx.Outbound;
@@ -20,31 +19,31 @@ namespace Vlingo.Cluster.Model.Outbound
     {
         void Close(Id id);
         
-        Task Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes);
+        void Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes);
         
-        Task Directory(IEnumerable<Node> allLiveNodes);
+        void Directory(IEnumerable<Node> allLiveNodes);
         
-        Task Elect(IEnumerable<Node> allGreaterNodes);
+        void Elect(IEnumerable<Node> allGreaterNodes);
         
-        Task Join();
+        void Join();
         
-        Task Leader();
+        void Leader();
         
-        Task Leader(Id id);
+        void Leader(Id id);
         
-        Task Leave();
+        void Leave();
         
         void Open(Id id);
         
-        Task Ping(Id targetNodeId);
+        void Ping(Id targetNodeId);
         
-        Task Pulse(Id targetNodeId);
+        void Pulse(Id targetNodeId);
         
-        Task Pulse();
+        void Pulse();
         
-        Task Split(Id targetNodeId, Id currentLeaderId);
+        void Split(Id targetNodeId, Id currentLeaderId);
         
-        Task Vote(Id targetNodeId);
+        void Vote(Id targetNodeId);
     }
 
     public static class OperationalOutboundStreamFactory

--- a/src/Vlingo.Cluster/Model/Outbound/OperationalOutboundStreamActor.cs
+++ b/src/Vlingo.Cluster/Model/Outbound/OperationalOutboundStreamActor.cs
@@ -6,7 +6,6 @@
 // one at https://mozilla.org/MPL/2.0/.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Vlingo.Actors;
 using Vlingo.Cluster.Model.Message;
 using Vlingo.Wire.Message;
@@ -37,17 +36,17 @@ namespace Vlingo.Cluster.Model.Outbound
 
         public void Close(Id id) => _outbound.Close(id);
 
-        public async Task Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes)
+        public void Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes)
         {
             var buffer = _outbound.PooledByteBuffer();
             MessageConverters.MessageToBytes(says, buffer.AsStream());
             
             var message = _node.Id.Value.ToRawMessage(buffer.AsStream());
             
-            await _outbound.Broadcast(unconfirmedNodes, _outbound.BytesFrom(message, buffer));
+            _outbound.Broadcast(unconfirmedNodes, _outbound.BytesFrom(message, buffer));
         }
 
-        public async Task Directory(IEnumerable<Node> allLiveNodes)
+        public void Directory(IEnumerable<Node> allLiveNodes)
         {
             var dir = new Directory(_node.Id, _node.Name, allLiveNodes);
             
@@ -56,30 +55,30 @@ namespace Vlingo.Cluster.Model.Outbound
             
             var message = _node.Id.Value.ToRawMessage(buffer.AsStream());
             
-            await _outbound.Broadcast(_outbound.BytesFrom(message, buffer));
+            _outbound.Broadcast(_outbound.BytesFrom(message, buffer));
         }
 
-        public async Task Elect(IEnumerable<Node> allGreaterNodes) =>
-            await _outbound.Broadcast(allGreaterNodes, _cache.CachedRawMessage(OperationalMessage.ELECT));
+        public void Elect(IEnumerable<Node> allGreaterNodes) =>
+            _outbound.Broadcast(allGreaterNodes, _cache.CachedRawMessage(OperationalMessage.ELECT));
 
-        public async Task Join() => await _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.JOIN));
+        public void Join() => _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.JOIN));
 
-        public async Task Leader() => await _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.LEADER));
+        public void Leader() => _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.LEADER));
 
-        public async Task Leader(Id id) =>
-            await _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.LEADER), id);
+        public void Leader(Id id) =>
+            _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.LEADER), id);
 
-        public async Task Leave() => await _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.LEAVE));
+        public void Leave() => _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.LEAVE));
 
         public void Open(Id id) => _outbound.Open(id);
 
-        public async Task Ping(Id targetNodeId) => await _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.PING), targetNodeId);
+        public void Ping(Id targetNodeId) => _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.PING), targetNodeId);
 
-        public async Task Pulse(Id targetNodeId)  => await _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.PULSE), targetNodeId);
+        public void Pulse(Id targetNodeId)  => _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.PULSE), targetNodeId);
 
-        public async Task Pulse() => await _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.PULSE));
+        public void Pulse() => _outbound.Broadcast(_cache.CachedRawMessage(OperationalMessage.PULSE));
 
-        public async Task Split(Id targetNodeId, Id currentLeaderId)
+        public void Split(Id targetNodeId, Id currentLeaderId)
         {
             var split = new Split(currentLeaderId);
             
@@ -88,10 +87,10 @@ namespace Vlingo.Cluster.Model.Outbound
             
             var message = _node.Id.Value.ToRawMessage(buffer.AsStream());
             
-            await _outbound.SendTo(_outbound.BytesFrom(message, buffer), targetNodeId);
+            _outbound.SendTo(_outbound.BytesFrom(message, buffer), targetNodeId);
         }
         
-        public async Task Vote(Id targetNodeId) => await _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.VOTE), targetNodeId);    
+        public void Vote(Id targetNodeId) => _outbound.SendTo(_cache.CachedRawMessage(OperationalMessage.VOTE), targetNodeId);    
         
         #endregion
 

--- a/src/Vlingo.Cluster/Model/Outbound/OperationalOutboundStream__Proxy.cs
+++ b/src/Vlingo.Cluster/Model/Outbound/OperationalOutboundStream__Proxy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Vlingo.Actors;
-using System.Threading.Tasks;
 using Vlingo.Cluster.Model.Message;
 
 namespace Vlingo.Cluster.Model.Outbound
@@ -57,11 +56,11 @@ namespace Vlingo.Cluster.Model.Outbound
             }
         }
 
-        public Task Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes)
+        public void Application(ApplicationSays says, IEnumerable<Node> unconfirmedNodes)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Application(says, unconfirmedNodes).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Application(says, unconfirmedNodes);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, ApplicationRepresentation2);
@@ -77,14 +76,13 @@ namespace Vlingo.Cluster.Model.Outbound
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, ApplicationRepresentation2));
             }
 
-            return Task.CompletedTask;
         }
 
-        public Task Directory(IEnumerable<Node> allLiveNodes)
+        public void Directory(IEnumerable<Node> allLiveNodes)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Directory(allLiveNodes).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Directory(allLiveNodes);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, DirectoryRepresentation3);
@@ -99,15 +97,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, DirectoryRepresentation3));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Elect(IEnumerable<Node> allGreaterNodes)
+        public void Elect(IEnumerable<Node> allGreaterNodes)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Elect(allGreaterNodes).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Elect(allGreaterNodes);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, ElectRepresentation4);
@@ -121,15 +117,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, ElectRepresentation4));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Join()
+        public void Join()
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Join().Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Join();
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, JoinRepresentation5);
@@ -143,15 +137,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, JoinRepresentation5));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Leader()
+        public void Leader()
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Leader().Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Leader();
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, LeaderRepresentation6);
@@ -165,15 +157,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, LeaderRepresentation6));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Leader(Id id)
+        public void Leader(Id id)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Leader(id).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Leader(id);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, LeaderRepresentation7);
@@ -187,15 +177,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, LeaderRepresentation7));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Leave()
+        public void Leave()
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Leave().Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Leave();
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, LeaveRepresentation8);
@@ -209,8 +197,6 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, LeaveRepresentation8));
             }
-
-            return Task.CompletedTask;
         }
 
         public void Open(Id id)
@@ -233,11 +219,11 @@ namespace Vlingo.Cluster.Model.Outbound
             }
         }
 
-        public Task Ping(Id targetNodeId)
+        public void Ping(Id targetNodeId)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Ping(targetNodeId).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Ping(targetNodeId);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, PingRepresentation10);
@@ -251,15 +237,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, PingRepresentation10));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Pulse(Id targetNodeId)
+        public void Pulse(Id targetNodeId)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Pulse(targetNodeId).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Pulse(targetNodeId);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, PulseRepresentation11);
@@ -273,15 +257,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, PulseRepresentation11));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Pulse()
+        public void Pulse()
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Pulse().Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Pulse();
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, PulseRepresentation12);
@@ -295,15 +277,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, PulseRepresentation12));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Split(Id targetNodeId, Id currentLeaderId)
+        public void Split(Id targetNodeId, Id currentLeaderId)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Split(targetNodeId, currentLeaderId).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Split(targetNodeId, currentLeaderId);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, SplitRepresentation13);
@@ -317,15 +297,13 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, SplitRepresentation13));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task Vote(Id targetNodeId)
+        public void Vote(Id targetNodeId)
         {
             if (!actor.IsStopped)
             {
-                Action<IOperationalOutboundStream> consumer = x => x.Vote(targetNodeId).Wait();
+                Action<IOperationalOutboundStream> consumer = x => x.Vote(targetNodeId);
                 if (mailbox.IsPreallocated)
                 {
                     mailbox.Send(actor, consumer, null, VoteRepresentation14);
@@ -339,8 +317,6 @@ namespace Vlingo.Cluster.Model.Outbound
             {
                 actor.DeadLetters.FailedDelivery(new DeadLetter(actor, VoteRepresentation14));
             }
-
-            return Task.CompletedTask;
         }
 
         public void Stop()

--- a/src/Vlingo.Cluster/Vlingo.Cluster.csproj
+++ b/src/Vlingo.Cluster/Vlingo.Cluster.csproj
@@ -6,7 +6,7 @@
 
         <!-- NuGet Metadata -->
         <IsPackable>true</IsPackable>
-        <PackageVersion>0.3.2</PackageVersion>
+        <PackageVersion>0.4.0</PackageVersion>
         <PackageId>Vlingo.Cluster</PackageId>
         <Authors>Vlingo</Authors>
         <Description>

--- a/src/Vlingo.Cluster/Vlingo.Cluster.csproj
+++ b/src/Vlingo.Cluster/Vlingo.Cluster.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Vlingo.Actors" Version="0.3.5" />
-      <PackageReference Include="Vlingo.Wire" Version="0.4.2" />
+      <PackageReference Include="Vlingo.Wire" Version="0.5.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove `Task` and `async/await` from the code as it is no longer necessary. The underlying `wire` library is full async based on APM.