### PR TITLE
Upgrading dependencies with the new BasicCompletes implementation

### DIFF
--- a/src/Vlingo.Cluster/Vlingo.Cluster.csproj
+++ b/src/Vlingo.Cluster/Vlingo.Cluster.csproj
@@ -6,7 +6,7 @@
 
         <!-- NuGet Metadata -->
         <IsPackable>true</IsPackable>
-        <PackageVersion>0.4.6</PackageVersion>
+        <PackageVersion>0.4.7</PackageVersion>
         <PackageId>Vlingo.Cluster</PackageId>
         <Authors>Vlingo</Authors>
         <Description>

--- a/src/Vlingo.Cluster/Vlingo.Cluster.csproj
+++ b/src/Vlingo.Cluster/Vlingo.Cluster.csproj
@@ -34,9 +34,9 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Vlingo.Actors" Version="0.4.5" />
-      <PackageReference Include="Vlingo.Common" Version="0.5.3" />
-      <PackageReference Include="Vlingo.Wire" Version="0.5.6" />
+      <PackageReference Include="Vlingo.Actors" Version="0.4.7" />
+      <PackageReference Include="Vlingo.Common" Version="0.5.5" />
+      <PackageReference Include="Vlingo.Wire" Version="0.5.7" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade Vlingo.Actors to 0.4.7, Vlingo.Common to 0.5.5, Vlingo.Wire to 0.5.7